### PR TITLE
feat: support custom extractors via module:// URI scheme

### DIFF
--- a/docs/docs/scheme/input-config/config.md
+++ b/docs/docs/scheme/input-config/config.md
@@ -2,7 +2,21 @@
 
 The following keys are available for the input configuration:
 
-- `extractor`: Which extractor from `beanhub-extract` should be used? Currently, only extractors from `beanhub-extract` are supported, and you always need to specify it explicitly. We will open up to support a third-party extractor, and we will also add an auto-detection feature so that it will guess which extractor to use for you.
+- `extractor`: Which extractor to use for processing the matched file. This can be:
+  - A built-in extractor name from `beanhub-extract` (e.g., `mercury`, `chase_credit_card`, `plaid`)
+  - A custom extractor via module URI: `module://package.module.ExtractorClass` (e.g., `module://my_extractors.CustomExtractor`)
+  - `null` or omitted to enable auto-detection (beanhub-import will try to guess which built-in extractor to use)
+
+  **Note:** Custom extractors loaded via `module://` must:
+  - Implement the Extractor interface from beanhub-extract (have `__init__` accepting a file object and `__call__` returning a generator of Transaction objects)
+  - Be available in Python's `sys.path` (install the package or set `PYTHONPATH`)
+  - Be specified explicitly (auto-detection only works with built-in extractors)
+
+  **Example:**
+  ```yaml
+  extractor: "module://my_company.extractors.BankOfAmericaExtractor"
+  ```
+
 - `default_file`: The default output file for generated transactions from the matched file to use if not specified in the `add_txn` action.
 - `prepend_postings`: Postings are to be prepended for the generated transactions from the matched file. A list of posting templates as described in the [Add Transaction Action](../import-config/actions.md#add-transaction-action) section.
 - `append_postings`: Postings are to be appended to the generated transactions from the matched file. A list of posting templates as described in the [Add Transaction Action](../import-config/actions.md#add-transaction-action) section.


### PR DESCRIPTION
Adds ability to load third-party extractors using module:// URI prefix, addressing LaunchPlatform/beanhub-extract#2.

Example for imports.yaml: 

```
extractor: "module://my_pkg.extractors.BankExtractor"
```

Tradeoffs:
- Simple to iterate and develop custom extractors without needing to recursively patch/version bump beanhub-extract/beanhub-import/beanhub-cli.
- Runtime validation vs compile-time: Interface checks happen at load time, not import time. This allows flexible duck-typing but defers errors to runtime.
- importlib.import_module vs entry_points: Module path approach is simpler and doesn't require package installation/registration, but users must manage PYTHONPATH. Entry points would provide discovery but add installation complexity.
- Fail-fast on module errors: Raises ValueError immediately rather than silently skipping (unlike built-in extractor not-found which logs warning). Custom extractors are explicit user intent, so failures should be loud.

Benefits:
- Zero changes to beanhub-extract required
- Works with any class implementing extractor interface
- No package registration/entry points needed
- Clear separation: built-in names vs module:// URIs

TLDR - I'm trying out using this with a few of my own custom extractors and found it convenient and wished to contribute back.